### PR TITLE
chore: clean up unused imports and lints

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -4,7 +4,6 @@ API routes for the Lead Parser
 import logging
 from typing import Dict, Any
 from fastapi import APIRouter, HTTPException, Request, Depends
-from fastapi.responses import JSONResponse
 
 from app.models import (
     ParseRequest, ParseResponse, JobResponse, JobStatusResponse
@@ -33,7 +32,7 @@ async def parse_file(
     Synchronous file parsing endpoint for small/medium files
     """
     try:
-        logger.info(f"Parse request received")
+        logger.info("Parse request received")
         
         # Initialize parsing service
         parsing_service = ParsingService()
@@ -130,7 +129,7 @@ async def create_job(
     Create async job for large file processing
     """
     try:
-        logger.info(f"Job creation request received")
+        logger.info("Job creation request received")
         
         # Create job
         job_id = job_manager.create_job(request_data, correlation_id)
@@ -538,10 +537,8 @@ async def test_parse_file(
         # Test the complete workflow without upload
         from app.services.google_drive import GoogleDriveService
         from app.services.gemini import GeminiService  
-        from app.services.data_processor import DataProcessor
-        from app.services.parser import ParsingService
-        import time
         import pandas as pd
+        from app.services.data_processor import DataProcessor
         from io import BytesIO
         
         # Step 1: Download file
@@ -552,10 +549,8 @@ async def test_parse_file(
         file_io = BytesIO(file_content)
         if mime_type == 'text/csv' or file_name.lower().endswith('.csv'):
             df = pd.read_csv(file_io, encoding='utf-8')
-            file_type = 'csv'
         else:
             df = pd.read_excel(file_io, engine='openpyxl')
-            file_type = 'xlsx'
         
         # Step 3: Header mapping with Gemini
         gemini_service = GeminiService()

--- a/app/config.py
+++ b/app/config.py
@@ -2,7 +2,6 @@
 Configuration settings for the Lead Parser API
 """
 import os
-from typing import Optional
 from pydantic_settings import BaseSettings
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -1,7 +1,7 @@
 """
 Pydantic models for the Lead Parser API
 """
-from typing import Optional, Dict, List, Any, Union
+from typing import Optional, Dict, List
 from enum import Enum
 from pydantic import BaseModel, Field, model_validator
 

--- a/app/services/data_processor.py
+++ b/app/services/data_processor.py
@@ -4,7 +4,7 @@ Data processing service for normalizing and cleaning lead data
 import re
 import logging
 import pandas as pd
-from typing import Dict, List, Tuple, Any, Optional
+from typing import Dict, List, Tuple, Any
 from urllib.parse import urlparse, urlunparse
 import phonenumbers
 from email_validator import validate_email, EmailNotValidError
@@ -204,7 +204,7 @@ class DataProcessor:
             parsed = phonenumbers.parse(numeric_only, None)
             if phonenumbers.is_valid_number(parsed):
                 return phonenumbers.format_number(parsed, phonenumbers.PhoneNumberFormat.E164)
-        except:
+        except Exception:
             pass
         
         # Fallback: ensure leading + for international format

--- a/app/services/gemini.py
+++ b/app/services/gemini.py
@@ -4,7 +4,7 @@ Gemini service for header mapping using Gemini 2.5 Flash
 import json
 import logging
 import asyncio
-from typing import List, Dict, Any, Tuple
+from typing import List, Dict, Any
 import google.generativeai as genai
 from google.generativeai.types import HarmCategory, HarmBlockThreshold
 

--- a/app/services/google_drive.py
+++ b/app/services/google_drive.py
@@ -4,10 +4,9 @@ Google Drive service for file operations
 import os
 import io
 import logging
-from typing import Optional, Tuple, BinaryIO
+from typing import Tuple
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaIoBaseDownload, MediaIoBaseUpload
-from google.auth.transport.requests import Request
 from google.oauth2 import service_account
 from googleapiclient.errors import HttpError
 
@@ -157,7 +156,7 @@ class GoogleDriveService:
             if e.resp.status == 403:
                 if 'storageQuotaExceeded' in error_content:
                     logger.error(f"Storage quota exceeded for folder {folder_id}")
-                    raise ValueError(f"Storage quota exceeded. This may be a service account storage limit issue.")
+                    raise ValueError("Storage quota exceeded. This may be a service account storage limit issue.")
                 else:
                     logger.error(f"Access denied to folder {folder_id}. Ensure the folder is shared with the service account.")
                     raise ValueError(f"Access denied to folder {folder_id}. Please share the folder with the service account.")

--- a/app/services/job_manager.py
+++ b/app/services/job_manager.py
@@ -7,8 +7,7 @@ import logging
 import uuid
 from datetime import datetime, timedelta
 from typing import Dict, Optional, Any
-from dataclasses import dataclass, asdict
-from enum import Enum
+from dataclasses import dataclass
 
 from app.models import JobStatus, ParseRequest, ParseResponse, JobStatusResponse
 from app.services.parser import ParsingService

--- a/app/services/parser.py
+++ b/app/services/parser.py
@@ -6,7 +6,7 @@ import json
 import logging
 import pandas as pd
 import httpx
-from typing import Tuple, Optional
+from typing import Tuple
 from io import BytesIO
 
 from app.models import (

--- a/main.py
+++ b/main.py
@@ -1,7 +1,6 @@
 """
 Lead Parser API - Main application entry point
 """
-import os
 import logging
 import uuid
 from contextlib import asynccontextmanager
@@ -9,7 +8,6 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 import uvicorn
 
-from app.config import settings
 from app.api.routes import router
 from app.utils.logging import setup_logging
 


### PR DESCRIPTION
## Summary
- remove unused imports across modules and eliminate redundant f-strings
- clean up parsing test endpoint to add pandas import and drop unused variables
- fix bare except and f-string warnings detected by ruff

## Testing
- `ruff check .`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b12a081e288326af2f8439980ae60d